### PR TITLE
Pass number of context lines to getGroupedOpcodes

### DIFF
--- a/lib/difflib.js
+++ b/lib/difflib.js
@@ -1189,7 +1189,7 @@ Class Differ:
     }
     lines = [];
     started = false;
-    _ref1 = (new SequenceMatcher(null, a, b)).getGroupedOpcodes();
+    _ref1 = (new SequenceMatcher(null, a, b)).getGroupedOpcodes(n);
     for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
       group = _ref1[_i];
       if (!started) {
@@ -1319,7 +1319,7 @@ Class Differ:
     };
     started = false;
     lines = [];
-    _ref1 = (new SequenceMatcher(null, a, b)).getGroupedOpcodes();
+    _ref1 = (new SequenceMatcher(null, a, b)).getGroupedOpcodes(n);
     for (_i = 0, _len = _ref1.length; _i < _len; _i++) {
       group = _ref1[_i];
       if (!started) {


### PR DESCRIPTION
@qiao `The number of context lines is set by n which defaults to three` but that `n` value is never passed along.  Currently, only three lines of context is given, regardless of the n value, which is fixed with this PR.

```js
difflib.unifiedDiff(foo, bar, { n: 10 });
```

I'm trying to figure out how to get the tests to run so I can update them.  Let's see if I can get that sorted but I'm not sure if you're still active on github.